### PR TITLE
fix: typo in about page about GBP and name correction

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -33,7 +33,7 @@ const Recipes = () => (
 				<div className='mt-2 flex flex-col space-y-8'>
 					<p>
 						Yenny is a Japanese Yen (JPY) converter that can convert Japanese
-						Yen to the US Dollar (USD), Euros (EUR), Great British Pound (GPB),
+						Yen to the US Dollar (USD), Euros (EUR), British Pound Sterling (GBP),
 						and more currencies.
 					</p>
 					<p>


### PR DESCRIPTION
Fixed a typo in the ISO code for the currency used in the UK (GPB -> GBP) as well as using the correct currency name in the about page.